### PR TITLE
Mobile Block Margins

### DIFF
--- a/build/style-index-rtl.css
+++ b/build/style-index-rtl.css
@@ -1,1 +1,1 @@
-.wp-block-imagewize-about-block{box-sizing:border-box;margin:0;padding:0}.wp-block-imagewize-about-block .wp-block-image{display:flex;justify-content:center;margin:0}
+.wp-block-imagewize-about-block{box-sizing:border-box;margin:0;padding:0}.wp-block-imagewize-about-block .wp-block-image{display:flex;justify-content:center;margin:0}@media(max-width:768px){.wp-block-imagewize-about-block{margin-right:1rem;margin-left:1rem}.wp-block-imagewize-about-block .wp-block-columns{margin-right:0;margin-left:0}}

--- a/build/style-index.css
+++ b/build/style-index.css
@@ -1,1 +1,1 @@
-.wp-block-imagewize-about-block{box-sizing:border-box;margin:0;padding:0}.wp-block-imagewize-about-block .wp-block-image{display:flex;justify-content:center;margin:0}
+.wp-block-imagewize-about-block{box-sizing:border-box;margin:0;padding:0}.wp-block-imagewize-about-block .wp-block-image{display:flex;justify-content:center;margin:0}@media(max-width:768px){.wp-block-imagewize-about-block{margin-left:1rem;margin-right:1rem}.wp-block-imagewize-about-block .wp-block-columns{margin-left:0;margin-right:0}}

--- a/src/style.scss
+++ b/src/style.scss
@@ -13,4 +13,15 @@
         display: flex;
         justify-content: center;
     }
+    
+    // Mobile styles
+    @media (max-width: 768px) {
+        margin-left: 1rem;
+        margin-right: 1rem;
+        
+        .wp-block-columns {
+            margin-left: 0;
+            margin-right: 0;
+        }
+    }
 }


### PR DESCRIPTION
This pull request includes updates to the styling of the `.wp-block-imagewize-about-block` class to improve its responsiveness on mobile devices. The changes ensure that margins are appropriately adjusted for smaller screens.

Responsive design improvements:

* [`build/style-index-rtl.css`](diffhunk://#diff-88fd0e3a77818145025328a889a4a28bf155de15dd25ba1a2a376b70657f454eL1-R1): Added media query to adjust margins for `.wp-block-imagewize-about-block` and `.wp-block-columns` on screens with a maximum width of 768px.
* [`build/style-index.css`](diffhunk://#diff-83d49146084ffaed62eec1c73723557cab6e56a54d92168544d61dfac3977969L1-R1): Added media query to adjust margins for `.wp-block-imagewize-about-block` and `.wp-block-columns` on screens with a maximum width of 768px.
* [`src/style.scss`](diffhunk://#diff-c0a5ddd5b365322730802e8cb15c95c3b6e965cbd3e569c69a2f089753844cdbR16-R26): Added mobile-specific styles for `.wp-block-imagewize-about-block` and `.wp-block-columns` to adjust margins on screens with a maximum width of 768px.